### PR TITLE
Prevent the footer from covering the main content

### DIFF
--- a/_sass/minimal-mistakes/_footer.scss
+++ b/_sass/minimal-mistakes/_footer.scss
@@ -10,7 +10,7 @@
   width: 100%;
   clear: both;
   /* sticky footer fix start */
-  position: absolute;
+  /* position: absolute; */
   bottom: 0;
   height: auto;
   /* sticky footer fix end */


### PR DESCRIPTION
Before

<img width="1562" alt="Screen Shot 2022-07-20 at 20 41 00" src="https://user-images.githubusercontent.com/2891235/179963042-edc58e4d-6d56-41ca-b8f2-60e9408bd7f0.png">

After

<img width="1539" alt="Screen Shot 2022-07-20 at 20 41 17" src="https://user-images.githubusercontent.com/2891235/179963094-06f4d364-6f3c-4bb5-8718-437d669e6906.png">

