### PR TITLE
Remove the stray follow button on the homepage 

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -4,7 +4,7 @@ permalink: /
 author: DaCapo
 header:
   image: "assets/images/banner-2560x600.png"
-  author_profile: true
+author_profile: false
 ---
 
 


### PR DESCRIPTION
Before

![Screenshot 2023-03-19 at 18 14 37](https://user-images.githubusercontent.com/2891235/226160027-49e84ca1-99a4-49c8-b7ee-5f04b17b7ba4.png)

After

![Screenshot 2023-03-19 at 18 14 17](https://user-images.githubusercontent.com/2891235/226160032-04e02386-6596-42bb-b7a8-63dadc04676d.png)

Minimal mistake generates a sidebar that has a follow button for smaller screens. But since there's no actual author profile to display, the button become confusing for people reading the site on the phone.